### PR TITLE
We need sudo; force it on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: true
 matrix:
     include:
         - os: linux


### PR DESCRIPTION
I ran a test with my repo, by default it ran the jobs on the new container based infrastructure that doesn't support sudo.  Therefore I've turned in on in .travis.yml. Naturally the test didn't actually build anything on OSX, since it has to be manually enabled on the repo :)
http://docs.travis-ci.com/user/multi-os/